### PR TITLE
Replace une playlist sur le Ka-50 dans les vidéos à trier

### DIFF
--- a/content/apprentissage/ajs-37/_index.md
+++ b/content/apprentissage/ajs-37/_index.md
@@ -12,7 +12,6 @@ weight = 7
 
 # clubby37
 - [DCS Viggen - Comprehensive Guide](https://www.youtube.com/playlist?list=PL7pn4rQD0F5YnST2SaCl5y90UD15_SHBc), d'excellents tutos sur le Viggen, à ne pas rater.
-- [Ka-50 Guide](https://www.youtube.com/playlist?list=PL7pn4rQD0F5Y9Y_MVqDdIhtZWcBIz_cN0), une autre série de tutoriels, cette fois sur le Ka-50. On manque de recul sur le contenu, mais on ne doute pas que ce soit aussi bien que la série sur le Viggen.
 - ...
 
 # TrakDah

--- a/content/web/videos/_index.md
+++ b/content/web/videos/_index.md
@@ -111,3 +111,6 @@ Des tutos très courts en anglais sur A-10A, F-15C, SU-25, SU-27, Mig-29...
 # DCS Debrief
 - [DCS Debrief](https://www.youtube.com/channel/UCERjcJzbzHmoBVPJpqn9RjQ/videos) des vidéos sur le combat
 
+
+# clubby37
+- [Ka-50 Guide](https://www.youtube.com/playlist?list=PL7pn4rQD0F5Y9Y_MVqDdIhtZWcBIz_cN0), du même auteur que la série sur l'AJS-37 Viggen. On manque de recul sur le contenu, mais on ne doute pas que ce soit aussi bien que celle-ci.


### PR DESCRIPTION
Alternativement, on peut la supprimer et se dire qu'on saura la retrouver si/quand l'un de nous jouera avec le Ka-50.